### PR TITLE
tqmls1028a: add env variables needed for syslinux and PXE boot

### DIFF
--- a/include/configs/tqmls1028a.h
+++ b/include/configs/tqmls1028a.h
@@ -199,6 +199,10 @@
 	BOOT_ENV_BOARD \
 	"loadaddr=0x82000000\0"                                                \
 	"fdtaddr=0x88000000\0"                                                 \
+	"kernel_addr_r=0x82000000\0"                                           \
+	"fdt_addr_r=0x88000000\0"                                              \
+	"pxefile_addr_r=0x88800000\0"                                          \
+	"ramdisk_addr_r=0x89000000\0"                                          \
 	"addtty=setenv bootargs ${bootargs} console=${console}\0"              \
 	"addmmc=setenv bootargs ${bootargs} root=/dev/mmcblk${mmcdev}p2 rootwait\0" \
 	"firmwarepart=1\0"                                                     \


### PR DESCRIPTION
To use syslinux or PXE boot a few variables are needed to define where
to load the kernel, fdt, ramdisk and PXE config files. For consistency
we use the same addresses for kernel and FDT as used by the default
boot scripts.